### PR TITLE
Add the PHP pgsql extension to the app runtime #17

### DIFF
--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -27,6 +27,7 @@
             - apcu
             - yaml
             - imagick
+            - pgsql
             # - memcached
     # The relationships of the application with services or other applications.
     #

--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -15,6 +15,7 @@ applications:
                 - apcu
                 - yaml
                 - imagick
+                - pgsql
                 # - memcached
         # The relationships of the application with services or other applications.
         #


### PR DESCRIPTION
Closes #17

## Problem

The Platform.sh / Upsun build aborts during `composer install`:

```
drupal/ai_provider_amazeeio 1.3.2 requires ext-pgsql * -> it is missing from your system.
drupal/drupal_cms_ai 2.1.3 requires drupal/ai_provider_amazeeio ^1.2.7
E: Error building project: `composer` could not be run.
```

`drupal/drupal_cms_ai` pulls `drupal/ai_provider_amazeeio`, which has a hard `ext-pgsql` platform requirement. The app runtime enabled `sodium / apcu / yaml / imagick` but not `pgsql`.

## Change

Enable the `pgsql` PHP extension in the app `runtime.extensions`, in both config formats the repo ships:

- `.upsun/config.yaml`
- `.platform/applications.yaml`

2 files, `+2` lines. No dependency/lock changes.

### Checkpoints
- [x] File an issue about this project
- [x] Addition/Change/Update/Fix to this project
- [ ] Testing to ensure no regression
- [ ] Automated unit/functional testing coverage
- [ ] Developer Documentation support on feature change/addition
- [ ] User Guide Documentation support on feature change/addition
- [ ] UX/UI designer responsibilities
- [ ] Accessibility and Readability
- [x] Reviewed by a human
- [x] Code review by maintainers
- [ ] Full testing and approval
- [ ] Credit contributors
- [ ] Review with the product owner
- [ ] Update Release Notes
- [ ] Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
AI-Generated: Yes (add pgsql PHP extension to app config; reviewed by Rajab Natshah.)