### PR TITLE
Update to varbase_project 11.0.4 / Drupal core 11.4.4 security release #19

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
       }
   },
   "require": {
-    "composer/installers": "~2",
+    "composer/installers": "^2.3",
     "cweagans/composer-patches": "~2.0",
     "drupal/core": "~11.4.0",
     "drupal/core-composer-scaffold": "~11.4",
@@ -72,7 +72,8 @@
   },
     "extra": {
         "drupal-lenient": {
-            "allowed-list": ["drupal/ckeditor_media_resize"]
+            "allowed-list": ["drupal/ckeditor_media_resize"],
+            "constraint": "^11.4 || ^12"
         },
         "drupal-scaffold": {
             "locations": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "300a1dd9d624b46b8171088ff5a27dd6",
+    "content-hash": "17e633aa95f8b59a7ad60341095dbfa6",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2127,44 +2127,61 @@
         },
         {
             "name": "drupal/ai_context",
-            "version": "1.0.0-beta2",
+            "version": "1.0.0-beta3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/ai_context.git",
-                "reference": "1.0.0-beta2"
+                "reference": "1.0.0-beta3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/ai_context-1.0.0-beta2.zip",
-                "reference": "1.0.0-beta2",
-                "shasum": "e3927e8cb4388ec49be5d1d5e404e009e85b0537"
+                "url": "https://ftp.drupal.org/files/projects/ai_context-1.0.0-beta3.zip",
+                "reference": "1.0.0-beta3",
+                "shasum": "a20b3f73dfe1a27942d79dde636e9bebe8ad025a"
             },
             "require": {
-                "drupal/ai": ">=1.3.0-rc2@RC || ^2",
+                "drupal/ai": "^1.4 || ^2",
                 "drupal/ai_agents": "^1.2",
                 "drupal/core": "^10.5 || ^11.2",
-                "drupal/scheduler": "^2.2",
-                "drupal/scheduler_content_moderation_integration": "^3.0",
                 "league/commonmark": "^2.4"
             },
             "require-dev": {
+                "drupal/ai": "*",
                 "drupal/ai_agents_debugger": "^1.0@beta",
+                "drupal/ai_file_to_text": "^1.0",
                 "drupal/diff": "^1.0",
+                "drupal/document_loader": "^2.0.3",
+                "drupal/document_loader_mdx": "*",
+                "drupal/document_loader_media": "*",
                 "drupal/dynamic_entity_reference": "^3.2",
+                "drupal/scheduler": "^2.3",
+                "drupal/scheduler_content_moderation_integration": "^3.0",
                 "drush/drush": "^12|^13"
             },
             "suggest": {
-                "drupal/diff": "Allows to compare revisions of context items",
-                "drupal/dynamic_entity_reference": "Enable target entity scope and per-item target entity restrictions."
+                "cweagans/composer-patches": "Required for sites to apply the temporary patches declared in extra.patches.",
+                "drupal/ai_file_to_text": "Provides markdown editor importer support Word, PDFs, and a few other document formats.",
+                "drupal/canvas": "Required when using Context Items on Canvas-enabled sites; see extra.patches for a StringLongItemOverride workaround.",
+                "drupal/diff": "Allows you to compare revisions of context items",
+                "drupal/document_loader": "Provides markdown editor importer for common files (txt, md, pdf, docx, xlsx).",
+                "drupal/document_loader_webpage": "Provides markdown editor importer for URL content.",
+                "drupal/dynamic_entity_reference": "Scope plugin that allows you to associate context with one or more entity items.",
+                "drupal/scheduler": "Schedule publishing and unpublishing of context items.",
+                "drupal/scheduler_content_moderation_integration": "Schedule moderation state changes for context items."
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.0.0-beta2",
-                    "datestamp": "1783214261",
+                    "version": "1.0.0-beta3",
+                    "datestamp": "1784349133",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                },
+                "patches": {
+                    "drupal/canvas": {
+                        "3575644 - Skip StringLongItemOverride regex for ai_context_item": "patches/canvas-3575644-string-long-regex-ai-context-item.patch"
                     }
                 }
             },
@@ -2178,10 +2195,10 @@
                     "@lint:stylelint"
                 ],
                 "lint:cspell": [
-                    "npx --yes cspell \"**/*.{php,js,yml,md}\" --config .cspell.json"
+                    "npx --yes cspell \"**/*.{php,js,yml,md,twig,css}\" --config .cspell.json"
                 ],
                 "lint:phpcs": [
-                    "cd ../../../.. && vendor/bin/phpcs --standard=Drupal,DrupalPractice --extensions=php,module,inc,install,test,profile,theme,css,info,txt,md,yml web/modules/contrib/ai_context/src/ web/modules/contrib/ai_context/tests/"
+                    "cd ../../../.. && vendor/bin/phpcs --standard=Drupal,DrupalPractice --extensions=php,module,inc,install,test,profile,theme,css,info,txt,yml --ignore='*/.gitlab/*' web/modules/contrib/ai_context"
                 ],
                 "lint:phpstan": [
                     "cd ../../../.. && php -d memory_limit=512M vendor/bin/phpstan analyze web/modules/contrib/ai_context --configuration=web/modules/contrib/ai_context/phpstan.neon.dist"
@@ -2190,7 +2207,7 @@
                     "npx --yes eslint js/**/*.js"
                 ],
                 "lint:stylelint": [
-                    "npx --yes stylelint \"css/**/*.css\""
+                    "../../../core/node_modules/.bin/stylelint --config .stylelint-local.json --config-basedir ../../../core \"css/**/*.css\""
                 ]
             },
             "license": [
@@ -2421,17 +2438,17 @@
         },
         {
             "name": "drupal/ai_provider_amazeeio",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/ai_provider_amazeeio.git",
-                "reference": "1.3.2"
+                "reference": "1.3.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/ai_provider_amazeeio-1.3.2.zip",
-                "reference": "1.3.2",
-                "shasum": "44a6e3c37930289898cb653f66743f1c66a95ad4"
+                "url": "https://ftp.drupal.org/files/projects/ai_provider_amazeeio-1.3.3.zip",
+                "reference": "1.3.3",
+                "shasum": "f68db357313bc8a7e279d165531c88f9ae940ad0"
             },
             "require": {
                 "drupal/ai": "^1.3",
@@ -2446,8 +2463,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.3.2",
-                    "datestamp": "1783437690",
+                    "version": "1.3.3",
+                    "datestamp": "1784130248",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3871,26 +3888,26 @@
         },
         {
             "name": "drupal/ckeditor_media_resize",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/ckeditor_media_resize.git",
-                "reference": "1.0.0"
+                "reference": "1.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/ckeditor_media_resize-1.0.0.zip",
-                "reference": "1.0.0",
-                "shasum": "0e700e53a9aaedbd7586d3fc995201bed14e12a8"
+                "url": "https://ftp.drupal.org/files/projects/ckeditor_media_resize-1.1.0.zip",
+                "reference": "1.1.0",
+                "shasum": "b158f58590054f0e69a9bdbb106738323e4d3bea"
             },
             "require": {
-                "drupal/core": "^10.3.0 || ^11"
+                "drupal/core": "^8 || ^9 || ^10 || ^11 || ^12"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.0.0",
-                    "datestamp": "1730224770",
+                    "version": "1.1.0",
+                    "datestamp": "1759230011",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4394,16 +4411,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "11.4.2",
+            "version": "11.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "09d9b0087206f9b666f2356917b8c5b2afa26c11"
+                "reference": "37366eee85534e018eb53eadc261d26a46a9b6f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/09d9b0087206f9b666f2356917b8c5b2afa26c11",
-                "reference": "09d9b0087206f9b666f2356917b8c5b2afa26c11",
+                "url": "https://api.github.com/repos/drupal/core/zipball/37366eee85534e018eb53eadc261d26a46a9b6f4",
+                "reference": "37366eee85534e018eb53eadc261d26a46a9b6f4",
                 "shasum": ""
             },
             "require": {
@@ -4571,7 +4588,7 @@
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
             "support": {
-                "source": "https://github.com/drupal/core/tree/11.4.2"
+                "source": "https://github.com/drupal/core/tree/11.4.4"
             },
             "funding": [
                 {
@@ -4579,11 +4596,11 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-07-10T14:53:02+00:00"
+            "time": "2026-07-15T18:02:21+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "11.4.2",
+            "version": "11.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
@@ -4627,13 +4644,13 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-composer-scaffold/tree/11.4.2"
+                "source": "https://github.com/drupal/core-composer-scaffold/tree/11.4.4"
             },
             "time": "2026-07-09T23:23:24+00:00"
         },
         {
             "name": "drupal/core-project-message",
-            "version": "11.4.2",
+            "version": "11.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-project-message.git",
@@ -4671,13 +4688,13 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-project-message/tree/11.4.2"
+                "source": "https://github.com/drupal/core-project-message/tree/11.4.4"
             },
             "time": "2026-01-07T19:00:53+00:00"
         },
         {
             "name": "drupal/core-recipe-unpack",
-            "version": "11.4.2",
+            "version": "11.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recipe-unpack.git",
@@ -4718,29 +4735,29 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-recipe-unpack/tree/11.4.2"
+                "source": "https://github.com/drupal/core-recipe-unpack/tree/11.4.4"
             },
             "time": "2026-01-07T19:00:53+00:00"
         },
         {
             "name": "drupal/core-recommended",
-            "version": "11.4.2",
+            "version": "11.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recommended.git",
-                "reference": "d271fc4eadb32cffbd25d47a225e0595c0bc160e"
+                "reference": "17ea388598063ead0f9dc70cdaac8afaf2828048"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/d271fc4eadb32cffbd25d47a225e0595c0bc160e",
-                "reference": "d271fc4eadb32cffbd25d47a225e0595c0bc160e",
+                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/17ea388598063ead0f9dc70cdaac8afaf2828048",
+                "reference": "17ea388598063ead0f9dc70cdaac8afaf2828048",
                 "shasum": ""
             },
             "require": {
                 "asm89/stack-cors": "~v2.4.0",
                 "composer/semver": "~3.4.4",
                 "doctrine/lexer": "~3.0.1",
-                "drupal/core": "11.4.2",
+                "drupal/core": "11.4.4",
                 "egulias/email-validator": "~4.0.4",
                 "justinrainbow/json-schema": "~6.8.2",
                 "marc-mabe/php-enum": "~v4.7.2",
@@ -4796,13 +4813,13 @@
             ],
             "description": "Core and its dependencies with known-compatible minor versions. Require this project INSTEAD OF drupal/core.",
             "support": {
-                "source": "https://github.com/drupal/core-recommended/tree/11.4.2"
+                "source": "https://github.com/drupal/core-recommended/tree/11.4.4"
             },
-            "time": "2026-07-10T14:53:02+00:00"
+            "time": "2026-07-15T18:02:21+00:00"
         },
         {
             "name": "drupal/core-vendor-hardening",
-            "version": "11.4.2",
+            "version": "11.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-vendor-hardening.git",
@@ -4840,7 +4857,7 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-vendor-hardening/tree/11.4.2"
+                "source": "https://github.com/drupal/core-vendor-hardening/tree/11.4.4"
             },
             "time": "2026-01-07T19:00:53+00:00"
         },
@@ -7441,17 +7458,17 @@
         },
         {
             "name": "drupal/entityqueue",
-            "version": "1.11.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/entityqueue.git",
-                "reference": "8.x-1.11"
+                "reference": "8.x-1.12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/entityqueue-8.x-1.11.zip",
-                "reference": "8.x-1.11",
-                "shasum": "ed2a18d5fea5e0b4efa923d2d1e2d500f272415e"
+                "url": "https://ftp.drupal.org/files/projects/entityqueue-8.x-1.12.zip",
+                "reference": "8.x-1.12",
+                "shasum": "618b758abf1175bf63f461944c26deb38e408dd0"
             },
             "require": {
                 "drupal/core": "^10.2 || ^11 || ^12"
@@ -7465,8 +7482,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.11",
-                    "datestamp": "1783714392",
+                    "version": "8.x-1.12",
+                    "datestamp": "1784059695",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7499,20 +7516,20 @@
         },
         {
             "name": "drupal/entityqueue_form_widget",
-            "version": "2.0.8",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/entityqueue_form_widget.git",
-                "reference": "2.0.8"
+                "reference": "2.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/entityqueue_form_widget-2.0.8.zip",
-                "reference": "2.0.8",
-                "shasum": "1f4f9793521db4ded1e2df7a654d11f6990f044b"
+                "url": "https://ftp.drupal.org/files/projects/entityqueue_form_widget-2.1.0.zip",
+                "reference": "2.1.0",
+                "shasum": "9f67003692941e1897b7385a6d04c5513f513c58"
             },
             "require": {
-                "drupal/core": "^10 || ^11",
+                "drupal/core": "^11.4 || ^12",
                 "drupal/entityqueue": "~1.1"
             },
             "require-dev": {
@@ -7525,8 +7542,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.8",
-                    "datestamp": "1764004771",
+                    "version": "2.1.0",
+                    "datestamp": "1784175449",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -13847,17 +13864,17 @@
         },
         {
             "name": "drupal/trash",
-            "version": "3.0.29",
+            "version": "3.0.30",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/trash.git",
-                "reference": "3.0.29"
+                "reference": "3.0.30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/trash-3.0.29.zip",
-                "reference": "3.0.29",
-                "shasum": "bd57e41e2f291322ad32cd67109b8637f4bea6a4"
+                "url": "https://ftp.drupal.org/files/projects/trash-3.0.30.zip",
+                "reference": "3.0.30",
+                "shasum": "7b076dac56e885730f2038b569e5d417813838bf"
             },
             "require": {
                 "drupal/core": "^10.3 | ^11"
@@ -13876,8 +13893,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.0.29",
-                    "datestamp": "1782977464",
+                    "version": "3.0.30",
+                    "datestamp": "1784218555",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -14526,16 +14543,16 @@
         },
         {
             "name": "drupal/varbase_ai_taxonomy_tagging",
-            "version": "2.0.0-beta1",
+            "version": "2.0.0-beta2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/varbase_ai_taxonomy_tagging.git",
-                "reference": "2cc19a33cb91a0b88e17dc244115f9b49709dcd4"
+                "reference": "3cf261ba64eece57711863086a0f98dd256935eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://git.drupalcode.org/api/v4/projects/project%2Fvarbase_ai_taxonomy_tagging/repository/archive.zip?sha=2cc19a33cb91a0b88e17dc244115f9b49709dcd4",
-                "reference": "2cc19a33cb91a0b88e17dc244115f9b49709dcd4",
+                "url": "https://git.drupalcode.org/api/v4/projects/project%2Fvarbase_ai_taxonomy_tagging/repository/archive.zip?sha=3cf261ba64eece57711863086a0f98dd256935eb",
+                "reference": "3cf261ba64eece57711863086a0f98dd256935eb",
                 "shasum": ""
             },
             "require": {
@@ -14566,9 +14583,9 @@
                 "varbase recipe"
             ],
             "support": {
-                "source": "https://git.drupalcode.org/project/varbase_ai_taxonomy_tagging/-/tree/2.0.0-beta1"
+                "source": "https://git.drupalcode.org/project/varbase_ai_taxonomy_tagging/-/tree/2.0.0-beta2"
             },
-            "time": "2026-07-09T23:18:37+00:00"
+            "time": "2026-07-14T10:00:37+00:00"
         },
         {
             "name": "drupal/varbase_api_base",
@@ -15001,16 +15018,16 @@
         },
         {
             "name": "drupal/varbase_editor_base",
-            "version": "1.0.0-beta1",
+            "version": "1.0.0-beta2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/varbase_editor_base.git",
-                "reference": "fe06f150e9a9bbb48f979aae8663569be4ab03e7"
+                "reference": "530718513984310b1e1017343422b76ecdbe4834"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://git.drupalcode.org/api/v4/projects/project%2Fvarbase_editor_base/repository/archive.zip?sha=fe06f150e9a9bbb48f979aae8663569be4ab03e7",
-                "reference": "fe06f150e9a9bbb48f979aae8663569be4ab03e7",
+                "url": "https://git.drupalcode.org/api/v4/projects/project%2Fvarbase_editor_base/repository/archive.zip?sha=530718513984310b1e1017343422b76ecdbe4834",
+                "reference": "530718513984310b1e1017343422b76ecdbe4834",
                 "shasum": ""
             },
             "require": {
@@ -15021,7 +15038,7 @@
                 "drupal/ckeditor_bidi": "~5",
                 "drupal/ckeditor_emoji": "~2",
                 "drupal/ckeditor_media_embed": "~2",
-                "drupal/ckeditor_media_resize": "~1",
+                "drupal/ckeditor_media_resize": "~1.1.0",
                 "drupal/core": "~11.4.0",
                 "drupal/edit_media_modal": "~2.1.0",
                 "drupal/editor_advanced_link": "~2.3.0",
@@ -15059,7 +15076,7 @@
                 "issues": "https://www.drupal.org/project/issues/varbase_editor_base",
                 "source": "http://cgit.drupalcode.org/varbase_editor_base"
             },
-            "time": "2026-07-09T18:41:41+00:00"
+            "time": "2026-07-17T01:59:41+00:00"
         },
         {
             "name": "drupal/varbase_i18n_base",
@@ -15930,17 +15947,17 @@
         },
         {
             "name": "drupal/views_bulk_operations",
-            "version": "4.4.5",
+            "version": "4.4.7",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/views_bulk_operations.git",
-                "reference": "4.4.5"
+                "reference": "4.4.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/views_bulk_operations-4.4.5.zip",
-                "reference": "4.4.5",
-                "shasum": "0f4a674e79149ad7306209ac90890d9ba6f60d14"
+                "url": "https://ftp.drupal.org/files/projects/views_bulk_operations-4.4.7.zip",
+                "reference": "4.4.7",
+                "shasum": "eacf78c01dba6dabb44a65db8761aabff504f88b"
             },
             "require": {
                 "drupal/core": "^10.3 || ^11"
@@ -15949,10 +15966,10 @@
                 "drush/drush": "<12.5.1"
             },
             "require-dev": {
-                "drupal/coder": "^8.3.16",
+                "drupal/search_api": "^1.35",
                 "drush/drush": "^12 || ^13",
-                "phpstan/phpstan-deprecation-rules": "^2",
-                "phpstan/phpstan-strict-rules": "^2"
+                "phpstan/phpstan-deprecation-rules": "^1",
+                "phpstan/phpstan-strict-rules": "^1"
             },
             "suggest": {
                 "drush/drush": "^12 || ^13"
@@ -15960,8 +15977,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "4.4.5",
-                    "datestamp": "1778674066",
+                    "version": "4.4.7",
+                    "datestamp": "1784189101",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -16179,7 +16196,7 @@
             "extra": {
                 "drupal": {
                     "version": "6.3.0",
-                    "datestamp": "1783604819",
+                    "datestamp": "1783989705",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -17165,22 +17182,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.14.0",
+            "version": "7.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "aef242412e13128b5049864867bb49fc37dd39de"
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/aef242412e13128b5049864867bb49fc37dd39de",
-                "reference": "aef242412e13128b5049864867bb49fc37dd39de",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^2.5.1",
-                "guzzlehttp/psr7": "^2.12.4",
+                "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -17193,7 +17210,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.3",
-                "guzzlehttp/test-server": "^0.6",
+                "guzzlehttp/test-server": "^0.7",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -17273,7 +17290,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.14.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
             },
             "funding": [
                 {
@@ -17289,7 +17306,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-08T22:54:09+00:00"
+            "time": "2026-07-18T11:23:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -17377,16 +17394,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.4",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "51e27f9e2b332ab3e72f4520d5ff4f3c68c3577c"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/51e27f9e2b332ab3e72f4520d5ff4f3c68c3577c",
-                "reference": "51e27f9e2b332ab3e72f4520d5ff4f3c68c3577c",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
@@ -17476,7 +17493,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.4"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -17492,7 +17509,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-08T15:56:20+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
         },
         {
             "name": "html2text/html2text",
@@ -17741,16 +17758,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.2",
+            "version": "2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
+                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/1902f60f984235023acbe03db6ad614a37b3c3e7",
+                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7",
                 "shasum": ""
             },
             "require": {
@@ -17772,8 +17789,8 @@
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "^1.4 || ^2.0",
                 "nyholm/psr7": "^1.5",
-                "phpstan/phpstan": "^1.8.2",
-                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "phpstan/phpstan": "^2.0.0",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0 || ^12.0.0 || ^13.0.0",
                 "scrutinizer/ocular": "^1.8.1",
                 "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
                 "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
@@ -17844,7 +17861,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-19T13:16:38+00:00"
+            "time": "2026-07-12T15:29:16+00:00"
         },
         {
             "name": "league/config",
@@ -19083,16 +19100,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.4",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
-                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "url": "https://api.github.com/repos/nette/utils/zipball/b043439dbdf954e6c28b5ea7e34b0100f83165e0",
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0",
                 "shasum": ""
             },
             "require": {
@@ -19112,7 +19129,7 @@
             },
             "suggest": {
                 "ext-gd": "to use Image",
-                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-iconv": "to use Strings::chr(), ord() and reverse()",
                 "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
                 "ext-json": "to use Nette\\Utils\\Json",
                 "ext-mbstring": "to use Strings::lower() etc...",
@@ -19168,9 +19185,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.4"
+                "source": "https://github.com/nette/utils/tree/v4.1.5"
             },
-            "time": "2026-05-11T20:49:54+00:00"
+            "time": "2026-07-17T23:02:45+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -20994,16 +21011,16 @@
         },
         {
             "name": "swagger-api/swagger-ui",
-            "version": "v5.32.8",
+            "version": "v5.32.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swagger-api/swagger-ui.git",
-                "reference": "4e0d3f88de7db0395a80ef0541ff428f0926d484"
+                "reference": "08bb057df45fa778351ccea63dfedf848d5c5edf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/4e0d3f88de7db0395a80ef0541ff428f0926d484",
-                "reference": "4e0d3f88de7db0395a80ef0541ff428f0926d484",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/08bb057df45fa778351ccea63dfedf848d5c5edf",
+                "reference": "08bb057df45fa778351ccea63dfedf848d5c5edf",
                 "shasum": ""
             },
             "type": "library",
@@ -21049,9 +21066,9 @@
             ],
             "support": {
                 "issues": "https://github.com/swagger-api/swagger-ui/issues",
-                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.32.8"
+                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.32.9"
             },
-            "time": "2026-06-23T08:15:35+00:00"
+            "time": "2026-07-17T08:23:23+00:00"
         },
         {
             "name": "symfony/console",
@@ -24478,16 +24495,16 @@
         },
         {
             "name": "vardot/drupal-core-patches",
-            "version": "11.4.0.4",
+            "version": "11.4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Vardot/drupal-core-patches.git",
-                "reference": "6ba0a353bf53db16ddf6b2209bf3e37a56171c09"
+                "reference": "c7a534a0a42c8d507469e8e8d1a8fd04d228ee9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Vardot/drupal-core-patches/zipball/6ba0a353bf53db16ddf6b2209bf3e37a56171c09",
-                "reference": "6ba0a353bf53db16ddf6b2209bf3e37a56171c09",
+                "url": "https://api.github.com/repos/Vardot/drupal-core-patches/zipball/c7a534a0a42c8d507469e8e8d1a8fd04d228ee9d",
+                "reference": "c7a534a0a42c8d507469e8e8d1a8fd04d228ee9d",
                 "shasum": ""
             },
             "require": {
@@ -24548,22 +24565,22 @@
             ],
             "support": {
                 "issues": "https://github.com/Vardot/drupal-core-patches/issues",
-                "source": "https://github.com/Vardot/drupal-core-patches/tree/11.4.0.4"
+                "source": "https://github.com/Vardot/drupal-core-patches/tree/11.4.0.6"
             },
-            "time": "2026-07-03T15:05:38+00:00"
+            "time": "2026-07-14T16:36:33+00:00"
         },
         {
             "name": "vardot/varbase",
-            "version": "11.0.0-beta1",
+            "version": "11.0.0-beta2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Vardot/varbase.git",
-                "reference": "167515f0d33bacf3829d43c8340dbbb8f2024380"
+                "reference": "06195fb4840d6e8ef929de38384c3dcfe3011449"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Vardot/varbase/zipball/167515f0d33bacf3829d43c8340dbbb8f2024380",
-                "reference": "167515f0d33bacf3829d43c8340dbbb8f2024380",
+                "url": "https://api.github.com/repos/Vardot/varbase/zipball/06195fb4840d6e8ef929de38384c3dcfe3011449",
+                "reference": "06195fb4840d6e8ef929de38384c3dcfe3011449",
                 "shasum": ""
             },
             "require": {
@@ -24588,20 +24605,20 @@
                 "issues": "http://drupal.org/project/issues/varbase",
                 "source": "http://cgit.drupalcode.org/varbase"
             },
-            "time": "2026-07-12T06:36:02+00:00"
+            "time": "2026-07-16T12:26:36+00:00"
         },
         {
             "name": "vardot/varbase-patches",
-            "version": "11.0.21",
+            "version": "11.0.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Vardot/varbase-patches.git",
-                "reference": "1995cf7fcefb81f2bee6427474130d35fe251bbc"
+                "reference": "ddd0ee76b5bfc7c80046f58891f39d5213255fed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Vardot/varbase-patches/zipball/1995cf7fcefb81f2bee6427474130d35fe251bbc",
-                "reference": "1995cf7fcefb81f2bee6427474130d35fe251bbc",
+                "url": "https://api.github.com/repos/Vardot/varbase-patches/zipball/ddd0ee76b5bfc7c80046f58891f39d5213255fed",
+                "reference": "ddd0ee76b5bfc7c80046f58891f39d5213255fed",
                 "shasum": ""
             },
             "require": {
@@ -24616,6 +24633,9 @@
             "extra": {
                 "class": "Vardot\\VarbasePatches\\Plugin\\VarbasePatchesPlugin",
                 "patches": {
+                    "drupal/ai": {
+                        "fix: #3586589 Do not assume action definitions have a type when deriving action plugin functions": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/ai--2026-07-14--3586589--mr-1799.patch"
+                    },
                     "drupal/gin": {
                         "fix: #3590827 Sticky form actions appear on node revision revert/delete confirm forms (incomplete exclusion pattern)": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/gin--2026-05-19--3590827--mp-787.patch"
                     },
@@ -24734,6 +24754,9 @@
                     },
                     "drupal/ai_provider_anthropic": {
                         "fix: #3607044 Chat: requests rejected when the conversation ends with a non-user (assistant/system) message": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/ai_provider_anthropic--2026-06-30--3607044--mr-30.patch"
+                    },
+                    "drupal/ckeditor_media_resize": {
+                        "chore: #3607786 Add Drupal Core ~11.4.0 support in the CKEditor Media Resize module on the 1.1.x branch": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/ckeditor_media_resize--2026-07-16--3607786--mr-30.patch"
                     }
                 }
             },
@@ -24765,9 +24788,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Vardot/varbase-patches/issues",
-                "source": "https://github.com/Vardot/varbase-patches/tree/11.0.21"
+                "source": "https://github.com/Vardot/varbase-patches/tree/11.0.26"
             },
-            "time": "2026-07-10T13:25:31+00:00"
+            "time": "2026-07-16T19:45:33+00:00"
         },
         {
             "name": "yethee/tiktoken",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,13 @@
     "lint:yaml": "node ./node_modules/eslint/bin/eslint.js --config=.eslintrc.json --ext .yml .",
     "lint:js": "node ./node_modules/eslint/bin/eslint.js --config=.eslintrc.json --ext .js .",
     "lint:css": "npx stylelint --config=.stylelintrc.json",
+    "test": "node ./node_modules/@cucumber/cucumber/bin/cucumber.js --config cucumber.js",
     "test:chromium": "BROWSER=chromium node ./node_modules/@cucumber/cucumber/bin/cucumber.js --config cucumber.js",
     "test:firefox": "BROWSER=firefox node ./node_modules/@cucumber/cucumber/bin/cucumber.js --config cucumber.js",
     "test:webkit": "BROWSER=webkit node ./node_modules/@cucumber/cucumber/bin/cucumber.js --config cucumber.js",
+    "test:headed": "HEADLESS=false node ./node_modules/@cucumber/cucumber/bin/cucumber.js --config cucumber.js",
+    "test:fast": "SLOW_MO=0 node ./node_modules/@cucumber/cucumber/bin/cucumber.js --config cucumber.js",
+    "generate-reports": "node ./node_modules/webship-js/bin/generate-reports.js",
     "drupal-libraries-sync": "node ./recipes/varbase_starter/scripts/drupal-libraries-sync.js",
     "postinstall": "node ./recipes/varbase_starter/scripts/drupal-libraries-sync.js"
   },
@@ -93,7 +97,7 @@
     "typescript": "^6.0.2",
     "webpack": "~5",
     "webpack-cli": "~5",
-    "webship-js": "^2"
+    "webship-js": "^2.0.4"
   },
   "resolutions": {
     "webpack": "^5"

--- a/patches.lock.json
+++ b/patches.lock.json
@@ -1,5 +1,5 @@
 {
-    "_hash": "94b9bc3feeaf02af160321f2b7632601ffe3b4ea5bc690bc77e894a68e601b76",
+    "_hash": "919d9d376acbe53cffba97e5725f3454f1189066fd72436e7327c8f93a0bc3ff",
     "patches": {
         "drupal/core": [
             {
@@ -220,6 +220,18 @@
                 "depth": null,
                 "extra": {
                     "provenance": "dependency:drupal/core"
+                }
+            }
+        ],
+        "drupal/ai": [
+            {
+                "package": "drupal/ai",
+                "description": "fix: #3586589 Do not assume action definitions have a type when deriving action plugin functions",
+                "url": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/ai--2026-07-14--3586589--mr-1799.patch",
+                "sha256": null,
+                "depth": null,
+                "extra": {
+                    "provenance": "dependency:drupal/ai"
                 }
             }
         ],
@@ -762,6 +774,18 @@
                 "depth": null,
                 "extra": {
                     "provenance": "dependency:drupal/ai_provider_anthropic"
+                }
+            }
+        ],
+        "drupal/ckeditor_media_resize": [
+            {
+                "package": "drupal/ckeditor_media_resize",
+                "description": "chore: #3607786 Add Drupal Core ~11.4.0 support in the CKEditor Media Resize module on the 1.1.x branch",
+                "url": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/ckeditor_media_resize--2026-07-16--3607786--mr-30.patch",
+                "sha256": null,
+                "depth": null,
+                "extra": {
+                    "provenance": "dependency:drupal/ckeditor_media_resize"
                 }
             }
         ]

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -2,3 +2,5 @@
 /.ht.router.php
 /autoload_runtime.php
 /.ddev/traefik/
+/index.php
+/update.php

--- a/yarn.lock
+++ b/yarn.lock
@@ -9729,7 +9729,7 @@ __metadata:
     typescript: "npm:^6.0.2"
     webpack: "npm:~5"
     webpack-cli: "npm:~5"
-    webship-js: "npm:^2"
+    webship-js: "npm:^2.0.4"
   languageName: unknown
   linkType: soft
 
@@ -9890,7 +9890,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webship-js@npm:^2":
+"webship-js@npm:^2.0.4":
   version: 2.0.4
   resolution: "webship-js@npm:2.0.4"
   dependencies:


### PR DESCRIPTION
Fixes #19

Brings the Platform.sh / Upsun Varbase template in line with **[varbase_project 11.0.4](https://www.drupal.org/project/varbase_project/releases/11.0.4)**. The template was still locked to **Drupal core 11.4.2** — this is a security update.

Drupal core moves **11.4.2 -> 11.4.4** ([11.4.4 release](https://www.drupal.org/project/drupal/releases/11.4.4), 15 Jul 2026), covering:

* [SA-CORE-2026-010](https://www.drupal.org/sa-core-2026-010) Drupal core - Moderately critical - Information disclosure
* [SA-CORE-2026-011](https://www.drupal.org/sa-core-2026-011) Drupal core - Moderately critical - Cross-site scripting
* [SA-CORE-2026-012](https://www.drupal.org/sa-core-2026-012) Drupal core - Moderately critical - Cross-site scripting

### Changes

**composer.json** (minimal — the existing constraints already allowed the new versions)

- `composer/installers` `~2` -> `^2.3`
- `extra.drupal-lenient`: add `constraint: "^11.4 || ^12"`

Deliberately **not** copied from varbase_project 11.0.4: its `composer/composer: ^2.9` require and the `post-update-cmd` `@php -r "@unlink('vendor/bin/composer');"` hook — the Upsun build image provides composer itself. The template's own Upsun-specific bits are kept unchanged: `drupal/gleap-gleap`, `drupal/redis`, `platformsh/config-reader`, `config.bin-dir: vendor/bin`, `secure-http`, `preferred-install`, and the extra allow-plugins (`phpstan/extension-installer`, `dealerdirect/phpcodesniffer-composer-installer`, `pyrech/composer-changelogs`).

**package.json** — synced with varbase_project 11.0.4

- add the `test`, `test:headed`, `test:fast` and `generate-reports` scripts
- `webship-js` `^2` -> `^2.0.4`
- `packageManager` left at `yarn@4.17.1` (newer than varbase_project's `4.17.0` — not downgraded)

**web/.gitignore** — picks up the Drupal core 11.4.4 scaffold change that ignores `index.php` and `update.php` (both already removed from the repo in #17/#18).

**Regenerated locks** — `composer.lock`, `patches.lock.json`, `yarn.lock`.

### Verification

Ran `ddev composer update -W`. Resolves cleanly:

| Package | Before | After |
| --- | --- | --- |
| `drupal/core` | 11.4.2 | **11.4.4** |
| `drupal/core-recommended` | 11.4.2 | **11.4.4** |
| `vardot/varbase` | 11.0.0-beta1 | **11.0.0-beta2** |
| `vardot/varbase-patches` | 11.0.21 | **11.0.26** |
| `vardot/drupal-core-patches` | 11.4.0.4 | **11.4.0.6** |

- `mglaman/composer-drupal-lenient` **1.0.7**, `drupal/ckeditor_media_resize` **1.1.0** still installed via the lenient plugin.
- Patch gate ran clean: `varbase-patches: re-resolving patches with filter (allowed dependency patches)` -> `Patching drupal/core`.
- Composer reports **`No security vulnerability advisories found.`**
- `composer validate` passes (only the expected "version field present" template warning).

No built `web/` payload or `vendor/` is committed — only `composer.json`, `package.json`, the three lock files, and the scaffold-driven `web/.gitignore`.

---

**Checkpoints**

- [x] File an issue
- [x] Addition/Change/Update/Fix
- [x] Reviewed by a human
- [x] Code review by maintainers
