### PR TITLE
Refresh the Composer lock files after Varbase Patches 11.0.31 #25

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -24800,16 +24800,16 @@
         },
         {
             "name": "vardot/varbase-patches",
-            "version": "11.0.30",
+            "version": "11.0.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Vardot/varbase-patches.git",
-                "reference": "ed579241e3ea288694fab76277e8c4c21967153b"
+                "reference": "16882911f6e446a5f6801581e3f1662953ffd482"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Vardot/varbase-patches/zipball/ed579241e3ea288694fab76277e8c4c21967153b",
-                "reference": "ed579241e3ea288694fab76277e8c4c21967153b",
+                "url": "https://api.github.com/repos/Vardot/varbase-patches/zipball/16882911f6e446a5f6801581e3f1662953ffd482",
+                "reference": "16882911f6e446a5f6801581e3f1662953ffd482",
                 "shasum": ""
             },
             "require": {
@@ -24834,10 +24834,13 @@
                         "Issue #3517882: The namespace of EmbedCKEditor5PluginBase does not respect PSR4": "https://www.drupal.org/files/issues/2025-06-30/embed--2025-06-30--3517882--mr-26.patch"
                     },
                     "drupal/canvas": {
+                        "fix: #3591751 Compile on serve when a code component's compiled JS is empty": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/canvas--2026-07-26--3591751--mr-1424.patch",
                         "feat: #3567225 Allow per-node override of Content Template via checkbox in node selector": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/canvas--2026-07-10--3567225--mr-948.patch",
                         "feat: #3585221 Fall back to active version when stored component version is not available": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/canvas--2026-04-21--3585221--mr-927.patch",
                         "feat: #3584713 Add Allow Edit Global Regions permission to restrict editing of global page regions": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/canvas--2026-06-09--3584713--mr-911.patch",
                         "fix: #3591751 Compile JSX server-side for AI-created/edited code components (fixes [object Object])": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/canvas--2026-07-10--3591751--mr-1315.patch",
+                        "fix: #3560889 JsComponent crash renders Canvas Editor unusable when Image Props have relative example URLs": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/canvas--2026-07-26--3560889--mr-1425.patch",
+                        "fix: #3591876 Canvas AI: page builder discards the whole build when the LLM names a region that does not exist": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/canvas--2026-07-26--3591876--mr-1423.patch",
                         "fix: #3584883 Undefined array key placeholder warning in Component::getSlotDefinitions() when versioned_properties lacks last_active_version key": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/canvas--2026-04-15--3584883--mr-916.patch"
                     },
                     "drupal/coffee": {
@@ -24972,9 +24975,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Vardot/varbase-patches/issues",
-                "source": "https://github.com/Vardot/varbase-patches/tree/11.0.30"
+                "source": "https://github.com/Vardot/varbase-patches/tree/11.0.31"
             },
-            "time": "2026-07-26T09:47:45+00:00"
+            "time": "2026-07-26T15:05:48+00:00"
         },
         {
             "name": "yethee/tiktoken",

--- a/patches.lock.json
+++ b/patches.lock.json
@@ -1,5 +1,5 @@
 {
-    "_hash": "1d669a789d92baa78ca0331168da2648922a07278f99f24b85e58037f771d714",
+    "_hash": "e1e032095e22baa2356715cde2fc79471d402da8f3890654fcf2b0df293f9f0e",
     "patches": {
         "drupal/core": [
             {
@@ -262,6 +262,16 @@
         "drupal/canvas": [
             {
                 "package": "drupal/canvas",
+                "description": "fix: #3591751 Compile on serve when a code component's compiled JS is empty",
+                "url": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/canvas--2026-07-26--3591751--mr-1424.patch",
+                "sha256": null,
+                "depth": null,
+                "extra": {
+                    "provenance": "dependency:drupal/canvas"
+                }
+            },
+            {
+                "package": "drupal/canvas",
                 "description": "feat: #3567225 Allow per-node override of Content Template via checkbox in node selector",
                 "url": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/canvas--2026-07-10--3567225--mr-948.patch",
                 "sha256": null,
@@ -294,6 +304,26 @@
                 "package": "drupal/canvas",
                 "description": "fix: #3591751 Compile JSX server-side for AI-created/edited code components (fixes [object Object])",
                 "url": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/canvas--2026-07-10--3591751--mr-1315.patch",
+                "sha256": null,
+                "depth": null,
+                "extra": {
+                    "provenance": "dependency:drupal/canvas"
+                }
+            },
+            {
+                "package": "drupal/canvas",
+                "description": "fix: #3560889 JsComponent crash renders Canvas Editor unusable when Image Props have relative example URLs",
+                "url": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/canvas--2026-07-26--3560889--mr-1425.patch",
+                "sha256": null,
+                "depth": null,
+                "extra": {
+                    "provenance": "dependency:drupal/canvas"
+                }
+            },
+            {
+                "package": "drupal/canvas",
+                "description": "fix: #3591876 Canvas AI: page builder discards the whole build when the LLM names a region that does not exist",
+                "url": "https://raw.githubusercontent.com/vardot/varbase-patches/refs/heads/patches/canvas--2026-07-26--3591876--mr-1423.patch",
                 "sha256": null,
                 "depth": null,
                 "extra": {


### PR DESCRIPTION
Closes #25

Refreshes the committed dependency locks of the Varbase Upsun / Platform.sh deployment template to pick up Varbase Patches 11.0.31. `composer.lock` and `patches.lock.json` only. **`composer.json` is not touched**: the declared `vardot/varbase-patches: ~11.0.0` constraint already covers 11.0.31.

### composer.lock

| Package | From | To |
| --- | --- | --- |
| vardot/varbase-patches | 11.0.30 | 11.0.31 |

Nothing else moves. No package added, none removed, locked package count stays at 382.

Confirmed already the newest release inside the declared constraints, so unchanged: Drupal core and core-recommended 11.4.4 (`~11.4.0`), Varbase 11.0.0-beta2 (`~11.0.0`), Drupal Core Patches 11.4.0.6 (the 12.0.0.x line targets Drupal 12), Drupal Canvas 1.8.0.

The four alpha AI Figma packages that came in with the previous refresh (#23 / #24) are still locked and unchanged at 1.0.0-alpha1: `drupal/varbase_ai_figma_base`, `drupal/varbase_ai_figma`, `drupal/ai_figma`, `drupal/ai_agent_modes`. This pull request neither adds nor removes them.

### patches.lock.json

Patched-package count stays at 37. Total patch entries go from 68 to 71. The only change is `drupal/canvas`, from 5 to 8 entries, adding the three Drupal Canvas patches released in Varbase Patches 11.0.31:

- [#3591876](https://git.drupalcode.org/project/canvas/-/work_items/3591876) Canvas AI: page builder discards the whole build when the LLM names a region that does not exist.
- [#3591751](https://git.drupalcode.org/project/canvas/-/work_items/3591751) Compile on serve when a code component's compiled JS is empty.
- [#3560889](https://git.drupalcode.org/project/canvas/-/work_items/3560889) JsComponent crash renders Canvas Editor unusable when Image Props have relative example URLs.

No patch entry is removed.

### How it was generated and verified

Generated on top of `master` at `d1c97f1` in DDEV (PHP 8.4, Composer 2) with `composer update -W`, then `composer patches-relock`, then `composer patches-repatch`. `composer.json` is byte-identical before and after, so the lock content hash matches the committed file.

Verified:

- `composer validate` passes, with only the pre-existing "version field is present" advisory warning and no "lock file is not up to date".
- `composer patches-repatch` re-applies all 71 patch entries across 30 patched packages from scratch with no failure. `composer-exit-on-patch-failure` is `true`, so a failing patch would abort.
- `composer audit`: no security vulnerability advisories found. The only non-zero signal is the pre-existing abandoned `oomphinc/composer-installers-extender`, unchanged from `master`.
- Clean-room acceptance: a brand-new container seeded with only `composer.json` plus the two regenerated locks runs a plain `composer install`, which reports "Installing dependencies from lock file", performs 382 installs / 0 updates / 0 removals with no solve, patches all 30 packages, completes the Drupal scaffold, and exits 0. The three files are byte-identical after the install, so recipe unpack does not mutate them.

`yarn.lock` is unaffected and is not part of this pull request.

This is a lock refresh, not a security release, and no Drupal core security advisory is involved.

### Checkpoints
- [x] File an issue about this project
- [x] Addition/Change/Update/Fix to this project
- [ ] Testing to ensure no regression
- [ ] Automated unit/functional testing coverage
- [ ] Developer Documentation support on feature change/addition
- [ ] User Guide Documentation support on feature change/addition
- [ ] UX/UI designer responsibilities
- [ ] Accessibility and Readability
- [x] Reviewed by a human
- [ ] Code review by maintainers
- [ ] Full testing and approval
- [ ] Credit contributors
- [ ] Review with the product owner
- [ ] Update Release Notes
- [ ] Release
