### PR TITLE
Add the pdo_pgsql PHP extension so the Upsun app can build Amazee AI Provider 1.4.1 #33

### DIFF
--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -16,6 +16,7 @@ applications:
                 - yaml
                 - imagick
                 - pgsql
+                - pdo_pgsql
                 # - memcached
         # The relationships of the application with services or other applications.
         #


### PR DESCRIPTION
Issue: https://github.com/Vardot/platformsh-varbase/issues/33

Adds `pdo_pgsql` to the `varbase` app's `runtime.extensions` in `.upsun/config.yaml`. One line. No `composer.json`, `composer.lock` or `patches.lock.json` change: **the locked package set is correct, the runtime declaration was incomplete.**

```diff
             extensions:
                 - sodium
                 - apcu
                 - yaml
                 - imagick
                 - pgsql
+                - pdo_pgsql
                 # - memcached
```

## What this fixes

**`master` has been un-deployable since [#30](https://github.com/Vardot/platformsh-varbase/pull/30) merged.** The GitHub integration pushed to Master and the build failed (Upsun activity `bagewjrvrhkms`, `100% / complete / failure`):

```
drupal/ai_provider_amazeeio 1.4.1 requires ext-pdo_pgsql * -> it is missing from your system.
Install or enable PHP's pdo_pgsql extension.

E: Error building project: `composer` could not be run.
E: Error: Unable to build application, aborting.
```

The merge of [#32](https://github.com/Vardot/platformsh-varbase/pull/32) will hit the same wall, because it does not touch `.upsun/config.yaml`.

## This is a regression from the lock refresh in #30, and the verification gap is mine

`drupal/ai_provider_amazeeio` moved **1.3.3 → 1.4.1** in that refresh and changed its platform requirement:

| Version | Requires |
| --- | --- |
| 1.3.3 | `ext-pgsql` |
| **1.4.1** | `ext-pdo`, **`ext-pdo_pgsql`** |

`pgsql` was added to the runtime in [#17](https://github.com/Vardot/platformsh-varbase/issues/17) / [#18](https://github.com/Vardot/platformsh-varbase/pull/18) for this exact package, back when `ext-pgsql` was what it asked for. The requirement changed underneath the template and the declaration did not follow.

**#30's clean-room install should have caught this and did not.** It ran inside the DDEV container, which ships both extensions:

```
$ ddev exec 'php -m | grep -i pgsql'
pdo_pgsql
pgsql
```

So it proved the lock installs on **DDEV's** extension set, not on the set `.upsun/config.yaml` declares for the Upsun app. A clean-room install is only as good as the runtime it models, and it modelled the wrong one. Installing somewhere convenient is not the same as installing on the declared runtime.

## Audit of the whole lock, so this is not just a spot fix

I diffed the `ext-*` requirements of **all 383 resolved packages** in `composer.lock` against the app's declared extensions plus PHP 8.4's defaults. **`ext-pdo_pgsql` is the only genuine miss.**

| Extension | Required by | Status |
| --- | --- | --- |
| `ext-pdo_pgsql` | `drupal/ai_provider_amazeeio` | **missing, fixed here** |
| `ext-sodium` | `lcobucci/jwt` | declared |
| `ext-pdo`, `ext-gd`, `ext-dom`, `ext-mbstring`, `ext-openssl`, `ext-simplexml`, `ext-tokenizer`, `ext-xml`, `ext-xmlwriter`, `ext-zlib`, and the rest | core and contrib | PHP 8.4 defaults |

`ext-reflection` (required by `marc-mabe/php-enum`) also appears but is compiled into PHP and never needs declaring.

**Process change this should drive:** every future lock refresh diffs the `ext-*` requirements of the resolved packages against `.upsun/config.yaml` before the PR is opened. A green `composer install` somewhere else is not evidence.

## Verification

- `.upsun/config.yaml` parses; `extensions` reads `['sodium', 'apcu', 'yaml', 'imagick', 'pgsql', 'pdo_pgsql']`.
- Diff against `master` (`e2b38e8`) is exactly one added line.
- The real proof is the deploy: after merge, the `GitHub integration pushed to Master` activity must reach `complete / success`, and `drush status` must report **11.4.5** rather than the 11.4.4 currently serving. I will confirm both rather than assume the merge is enough, which is the exact assumption that produced this situation.

## State of the demo while this is open

`https://demo.varbase.vardot.com/` is serving the installer: the database was dropped for the planned reinstall before this build failure was understood. Backup **`vdywifwas6nwy5ulu7rwwpely4`** was taken first, so nothing is lost. **No install will be run until this merges and the deploy succeeds**, because an install on the stale 11.4.4 codebase would have to be thrown away and would not be the 11.0.0-rc1 stack the demo exists to show.

AI-Generated: Yes

## Checkpoints

- [x] File an issue
- [x] Addition/Change/Update/Fix
- [x] Reviewed by a human
- [x] Code review by maintainers
