### PR TITLE
Remove the pdo_pgsql extension from the Upsun runtime, it does not fix the build #33

### DIFF
--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -16,7 +16,6 @@ applications:
                 - yaml
                 - imagick
                 - pgsql
-                - pdo_pgsql
                 # - memcached
         # The relationships of the application with services or other applications.
         #


### PR DESCRIPTION
Issue: https://github.com/Vardot/platformsh-varbase/issues/33

Removes `pdo_pgsql` from the `varbase` app's `runtime.extensions` in `.upsun/config.yaml`, restoring the list to `sodium, apcu, yaml, imagick, pgsql`.

```diff
             extensions:
                 - sodium
                 - apcu
                 - yaml
                 - imagick
                 - pgsql
-                - pdo_pgsql
                 # - memcached
```

## Why the line goes back out

**[#34](https://github.com/Vardot/platformsh-varbase/pull/34) added it to fix the failing build, and it did not fix it.** The build failed again after merge with the identical error, and the build trees differed (`5f7cfb5` vs `333aaa3`), so this was a genuine fresh build that picked the change up.

The reason it cannot work: the failing check runs in the **build** container, against `/etc/php/8.4/cli/php.ini`, while `runtime.extensions` configures the **runtime** container. The build log says so directly:

```
Found a `composer.json`, installing dependencies.
  W: Verifying lock file contents can be installed on current platform.
  W: Your lock file does not contain a compatible set of packages.
  W:     - drupal/ai_provider_amazeeio 1.4.1 requires ext-pdo_pgsql * -> it is missing from your system.
  W: To enable extensions, verify that they are enabled in your .ini files:
  W:     - /etc/php/8.4/cli/php.ini
```

Evidence from the deployed container:

```
php -m | grep -E 'pgsql|pdo'   →  PDO, pdo_mysql, pdo_sqlite, pgsql
PDO::getAvailableDrivers()     →  [mysql, sqlite]
```

`pgsql` is enabled through that same list, so the mechanism works; `pdo_pgsql` simply is not reaching the container that performs the check.

**The extension is also not needed on this deployment.** The site runs **MariaDB** (`relationships: database: 'db:mysql'`, service `mariadb:10.11`), so `drupal/ai_provider_amazeeio`'s PostgreSQL requirement is never exercised at runtime. Leaving a line that does nothing and is not needed would be unexplained config, so it is removed rather than kept.

## This PR does not make the build pass

Stating it plainly: **`master` still will not deploy.** The `ext-pdo_pgsql` platform check is unresolved and is a separate decision, deliberately not routed around here. No `config.platform.ext-pdo_pgsql`, no `--ignore-platform-req`, no constraint change on `drupal/ai_provider_amazeeio`.

For the record, `drupal/ai_provider_amazeeio` is a **transitive** dependency: `drupal/drupal_cms_ai` 2.1.3 requires `drupal/ai_provider_amazeeio ^1.2.7`. The template does not ask for it directly.

## Lock files: verified current, deliberately not touched

Regenerated in DDEV on **PHP 8.4.20 / Composer 2.10.2**, matching the Upsun `php:8.4` runtime. All three report no change, so none is included in this PR:

- `composer update` → **"Nothing to modify in lock file"**, 0 installs / 0 updates / 0 removals.
- `yarn install --mode=update-lockfile` → `yarn.lock` unchanged.
- `composer validate` → clean, only the pre-existing *"version field is present"* warning. **No stale-lock warning.**

Resolved stack, confirmed by `dist.reference` rather than by version string:

| Package | Version | `dist.reference` |
| --- | --- | --- |
| `vardot/varbase` | 11.0.0-rc1 | `0fbce97f43c9c99c…` |
| `drupal/varbase_starter` | 1.0.0-rc2 | `5efdac1f90d73654…` |
| `drupal/core` | 11.4.5 | `a07143587a57d892…` |
| `vardot/varbase-patches` | 11.0.38 | `724b32ebd83b8245…` |
| `vardot/drupal-core-patches` | 11.4.0.6 | `c7a534a0a42c8d50…` |
| `drupal/vartheme_bs5` | 5.0.0-rc4 | — |

383 packages, `patches.lock.json` at 36 patched packages / 69 entries, `stability-flags` empty, and **nothing resolves to a dev branch**.

AI-Generated: Yes

## Checkpoints

- [x] File an issue
- [x] Addition/Change/Update/Fix
- [x] Reviewed by a human
- [x] Code review by maintainers
