### PR TITLE
Ignore the PostgreSQL platform requirements in the build hooks instead of replacing them #42

### DIFF
--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -73,7 +73,7 @@
 
     # Configuration of the build of this application.
     build:
-        flavor: composer
+        flavor: none
 
     # The hooks executed at various points in the lifecycle of the application.
     hooks:
@@ -82,6 +82,13 @@
         build: |
             set -e
             cd $PLATFORM_APP_DIR
+            # drupal/ai_provider_amazeeio requires ext-pdo_pgsql, which is not in
+            # this app's runtime extensions on purpose. Ignore just that
+            # requirement rather than installing PostgreSQL. See issue #42.
+            composer install --no-dev --no-progress --prefer-dist \
+                --optimize-autoloader \
+                --ignore-platform-req=ext-pgsql \
+                --ignore-platform-req=ext-pdo_pgsql
             npx corepack enable
             npx corepack prepare yarn@4.13.0 --activate
             export PATH="$HOME/.yarn/bin:$PATH"

--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -56,7 +56,10 @@ applications:
                 source_path: 'console'
         # Configuration of the build of this application.
         build:
-            flavor: composer
+            # 'none' so the build hook owns the Composer step and can pass
+            # --ignore-platform-req for the pgsql extensions, which this runtime
+            # deliberately does not ship. See issue #42.
+            flavor: none
         # The hooks executed at various points in the lifecycle of the application.
         hooks:
             # The build hook runs after Composer to finish preparing up your code.
@@ -64,6 +67,13 @@ applications:
             build: |
                 set -e
                 cd $PLATFORM_APP_DIR
+                # drupal/ai_provider_amazeeio requires ext-pdo_pgsql, which is not
+                # in this app's runtime extensions on purpose. Ignore just that
+                # requirement rather than installing PostgreSQL. See issue #42.
+                composer install --no-dev --no-progress --prefer-dist \
+                    --optimize-autoloader \
+                    --ignore-platform-req=ext-pgsql \
+                    --ignore-platform-req=ext-pdo_pgsql
                 npx corepack enable
                 npx corepack prepare yarn@4.13.0 --activate
                 export PATH="$HOME/.yarn/bin:$PATH"

--- a/composer.json
+++ b/composer.json
@@ -41,10 +41,6 @@
   "conflict": {
     "drupal/drupal": "*"
   },
-  "replace": {
-    "ext-pgsql": "*",
-    "ext-pdo_pgsql": "*"
-  },
   "minimum-stability": "dev",
   "prefer-stable": true,
   "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d9e40ebbd8c49fa7d72c91fc4befcdbe",
+    "content-hash": "008688c469d187b890f18183bb63cc8a",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
Issue: https://github.com/Vardot/platformsh-varbase/issues/42

Fixes the `composer install` failure introduced by the `replace` block in #36 / #37, **without adding the PostgreSQL extensions to any runtime**.

### What changed

| File | Change |
| --- | --- |
| `composer.json` | Removes the 4-line `replace` block claiming `ext-pgsql` / `ext-pdo_pgsql` |
| `composer.lock` | `content-hash` only, from `composer update --lock` |
| `.upsun/config.yaml` | varbase app: `build.flavor: composer` → `none`, and the build hook now runs `composer install` itself with `--ignore-platform-req` for the two pgsql extensions |
| `.platform/applications.yaml` | Same change mirrored for the legacy Platform.sh config |

### Why not `config.platform`

`config.platform` would also have worked and is a smaller diff, but it declares to Composer that the extensions exist everywhere. The explicit decision here is to keep any mention of PostgreSQL out of the dependency metadata and confine the exemption to the one place that actually needs it: the build command on a runtime that deliberately does not ship the extension.

`replace` was the wrong tool for this: a root package that *replaces* a PHP extension cannot coexist with that extension being present, so it broke every runtime that has `pdo_pgsql` installed.

### Why the build flavor had to change

With `build.flavor: composer`, Upsun runs `composer install` itself and there is no way to pass `--ignore-platform-req`. That is precisely why #37 reached for `replace`. Switching the varbase app to `flavor: none` and writing the command in the build hook follows the pattern the **storybook** app in the same file already uses. The command replicates what the composer flavor did (`--no-dev --no-progress --prefer-dist --optimize-autoloader`) and adds only the two ignore flags. The runtime extension list is untouched — still `sodium`, `apcu`, `yaml`, `imagick`, with no pgsql.

### Verification

Tested in a throwaway DDEV clone of `master` at `683d1f9f` (PHP 8.4). The pgsql extensions were then disabled inside the container to simulate the Upsun runtime, and re-enabled afterwards.

| Scenario | Command | Result |
| --- | --- | --- |
| Extension **present** (DDEV, GitHub Actions) | plain `composer install` | **passes** — `Verifying lock file contents can be installed on current platform.` → `Nothing to install, update or remove`. On `master` this same command fails with `cannot coexist`. |
| Extension **absent** (Upsun) | plain `composer install` | fails as expected: `drupal/ai_provider_amazeeio 1.4.1 requires ext-pdo_pgsql * -> it is missing from your system` |
| Extension **absent** | the exact build-hook command from this PR | **passes** |

Also: `composer validate` passes with only the pre-existing "version field is present" warning, and both YAML files parse (`yaml.safe_load`).

### CI expectation

`Code Quality` has been red on `master` since the regression landed — run `32008422624` at `d689573`, and also at `a1f4fe3` and `69ac835`. On PR #41 the same four jobs failed (**PHPStan**, **Storybook build**, **Install Varbase**, **Create reports**) while **PHPCS** and **YAML lint** passed, all four dying in the shared `Build the codebase` step. This PR is expected to turn those green — letting the checks prove it rather than claiming it.

### Out of scope

`composer audit` reports 1 security advisory, and `oomphinc/composer-installers-extender` is abandoned. Both pre-exist and are untouched here. A `package.json` `packageManager` bump appeared locally as a yarn artifact and was deliberately excluded.

## Checkpoints

- [x] File an issue
- [x] Addition/Change/Update/Fix
- [ ] Testing to ensure no regression
- [ ] Automated unit testing coverage
- [ ] Automated functional testing coverage
- [ ] Readability
- [ ] Accessibility
- [ ] Performance
- [ ] Security
- [ ] Developer Documentation
- [ ] User Guide Documentation
- [ ] Reviewed by a human
- [ ] Code review by maintainers
- [ ] Full testing and approval
- [ ] Credit contributors
- [ ] Release notes snippet
- [ ] Release
