### PR TITLE
Remove the PostgreSQL PHP extensions from the DDEV web container so the build works locally #46

### DIFF
--- a/.ddev/web-build/Dockerfile.nopgsql
+++ b/.ddev/web-build/Dockerfile.nopgsql
@@ -1,0 +1,8 @@
+# Match the Upsun runtime: this app ships no PostgreSQL extensions
+# (.upsun/config.yaml runtime.extensions = sodium, apcu, yaml, imagick).
+# composer.json declares `replace` for ext-pgsql / ext-pdo_pgsql, and a root
+# package that replaces an extension cannot coexist with the extension being
+# present, so `composer install` fails wherever pgsql is loaded. Removing the
+# extensions here keeps DDEV consistent with production. Varbase uses
+# MariaDB/MySQL; nothing in the stack needs PostgreSQL locally.
+RUN rm -f /etc/php/*/cli/conf.d/*pgsql*.ini /etc/php/*/fpm/conf.d/*pgsql*.ini /etc/php/*/apache2/conf.d/*pgsql*.ini || true


### PR DESCRIPTION
Issue: https://github.com/Vardot/platformsh-varbase/issues/46

Makes `ddev composer install` work on a fresh clone, **without touching `composer.json`**. The `replace` block for `ext-pgsql` / `ext-pdo_pgsql` stays exactly as it is and remains the only place PostgreSQL is mentioned in Composer metadata.

### The change — one new file

`.ddev/web-build/Dockerfile.nopgsql`

```dockerfile
RUN rm -f /etc/php/*/cli/conf.d/*pgsql*.ini /etc/php/*/fpm/conf.d/*pgsql*.ini /etc/php/*/apache2/conf.d/*pgsql*.ini || true
```

### Why here and not in Composer

The Upsun runtime ships no PostgreSQL extensions on purpose — `.upsun/config.yaml` → `runtime.extensions: sodium, apcu, yaml, imagick` — which is why `composer.json` declares `replace` for them. But the DDEV web container loads `pdo_pgsql` and `pgsql` by default, and a root package that *replaces* an extension cannot coexist with that extension being present:

```
Only one of these can be installed: ext-pdo_pgsql[8.4.20], vardot/platformsh-varbase[11.0.0].
vardot/platformsh-varbase replaces ext-pdo_pgsql and thus cannot coexist with it.
```

`--ignore-platform-req=ext-pdo_pgsql` does not help — it is a `replace` conflict resolved while building the pool, not an unmet platform requirement.

**Varbase runs on MariaDB/MySQL. Nothing in the stack uses PostgreSQL.** So rather than working around the conflict in Composer, this makes the local container match production: no pgsql in either place, and therefore no conflict. There is precedent in the same directory — `.ddev/web-build/Dockerfile` already enables Apache proxy modules for the Storybook subdomain.

### Verification

Reproduced the failure on a real copy of the template (`cp -r` to a new directory, `ddev start`, `ddev composer install -vvv`) and confirmed the loaded ini list included `20-pdo_pgsql.ini` and `20-pgsql.ini`.

After adding this file and running `ddev restart`:

| Check | Result |
| --- | --- |
| `php -m \| grep pgsql` in the web container | no output — extensions gone |
| `ddev composer install` | **passes** — `Verifying lock file contents can be installed on current platform.` → `Nothing to install, update or remove` |
| `composer validate` | passes, only the pre-existing "version field is present" warning |
| `yarn install` | passes |
| `ddev drush status` | Drupal 11.4.5, PHP 8.4 |
| `vendor/autoload.php`, `recipes/varbase_starter/recipe.yml` | present |

`composer.json`, `composer.lock`, `.upsun/config.yaml` and `.platform/applications.yaml` are all untouched by this PR.

### Out of scope

GitHub Actions still fails the same way, because setup-php's base PHP also provides `pdo_pgsql` (8.4.24) regardless of the `extensions:` input, which never requests pgsql. `Code Quality` has therefore been red on `master` since #37 and will stay red on this PR — inherited, not introduced. Tracked in #42.

## Checkpoints

- [x] File an issue
- [x] Addition/Change/Update/Fix
- [ ] Testing to ensure no regression
- [ ] Automated unit testing coverage
- [ ] Automated functional testing coverage
- [ ] Readability
- [ ] Accessibility
- [ ] Performance
- [ ] Security
- [ ] Developer Documentation
- [ ] User Guide Documentation
- [x] Reviewed by a human
- [x] Code review by maintainers
- [ ] Full testing and approval
- [ ] Credit contributors
- [ ] Release notes snippet
- [ ] Release
