### PR TITLE
Drop the PostgreSQL PHP extensions from the DDEV web container so the local build works #46

### DIFF
--- a/.ddev/web-build/Dockerfile.nopgsql
+++ b/.ddev/web-build/Dockerfile.nopgsql
@@ -1,0 +1,8 @@
+# Match the Upsun runtime: this app ships no PostgreSQL extensions
+# (.upsun/config.yaml runtime.extensions = sodium, apcu, yaml, imagick).
+# composer.json declares `replace` for ext-pgsql / ext-pdo_pgsql, and a root
+# package that replaces an extension cannot coexist with that extension being
+# present, so `composer install` fails wherever pgsql is loaded. Removing the
+# extensions here keeps DDEV consistent with production. Varbase runs on
+# MariaDB/MySQL; nothing in the stack needs PostgreSQL locally.
+RUN rm -f /etc/php/*/cli/conf.d/*pgsql*.ini /etc/php/*/fpm/conf.d/*pgsql*.ini /etc/php/*/apache2/conf.d/*pgsql*.ini || true


### PR DESCRIPTION
Issue: https://github.com/Vardot/platformsh-varbase/issues/46

Re-opened on top of the current `master` (`b8bc0f35`, after #45 merged). Supersedes the closed #47, which was based on `683d1f9f`. Same single-file change, now verified against the exact reproduction below.

### The reported failure

```
$ cp -r ~/workspace/products/upsun-varbase11x00 usv11
$ ddev delete -y && ddev start && ddev composer install -vvv
...
Problem 1
  - ext-pdo_pgsql is present at version 8.4.20 and cannot be modified by Composer
  - vardot/platformsh-varbase is present at version 11.0.0 and cannot be modified by Composer
  - Only one of these can be installed: ext-pdo_pgsql[8.4.20], vardot/platformsh-varbase[11.0.0].
    vardot/platformsh-varbase replaces ext-pdo_pgsql and thus cannot coexist with it.
```

The verbose output lists `/etc/php/8.4/cli/conf.d/20-pdo_pgsql.ini` and `20-pgsql.ini` among the loaded ini files — the DDEV web container provides both extensions by default.

### The change — one new file

`.ddev/web-build/Dockerfile.nopgsql`

```dockerfile
RUN rm -f /etc/php/*/cli/conf.d/*pgsql*.ini /etc/php/*/fpm/conf.d/*pgsql*.ini /etc/php/*/apache2/conf.d/*pgsql*.ini || true
```

`composer.json` is **not touched**. The `replace` block for `ext-pgsql` / `ext-pdo_pgsql` stays exactly as it is and remains the only place PostgreSQL is mentioned in Composer metadata. No `--ignore-platform-req`, no `config.platform`.

### Why this is the right layer

The Upsun runtime ships no PostgreSQL extensions on purpose — `.upsun/config.yaml` → `runtime.extensions: sodium, apcu, yaml, imagick` — which is exactly why `composer.json` declares `replace` for them. A root package that *replaces* an extension cannot coexist with that extension being present, so the conflict only appears where pgsql happens to be installed.

`--ignore-platform-req=ext-pdo_pgsql` does not help: this is a `replace` conflict resolved while building the dependency pool, not an unmet platform requirement.

**Varbase runs on MariaDB/MySQL — nothing in the stack uses PostgreSQL.** So rather than working around the conflict in Composer, this makes the local container match production. Precedent exists in the same directory: `.ddev/web-build/Dockerfile` already enables Apache proxy modules for the Storybook subdomain.

### Verification

Reproduced the failure exactly as reported, then applied this file and rebuilt:

| Check | Result |
| --- | --- |
| `php -m \| grep pgsql` in the web container | no output |
| `ls /etc/php/8.4/cli/conf.d/ \| grep pgsql` | no output |
| `ddev composer install -vvv` | **384 installs, 0 updates, 0 removals**, exit 0 |
| Patches | applied — core, canvas, gin, redirect, tagify, content_lock, coffee, ai_provider_anthropic, … |
| `composer validate` | passes, only the pre-existing "version field is present" warning |
| `ddev drush status` | Drupal 11.4.5, PHP 8.4 |
| `vendor/autoload.php`, `recipes/varbase_starter/recipe.yml`, `web/index.php` | present |

One operational note for reviewers: after adding the file, `ddev restart` can reuse a cached web image. `ddev debug rebuild -s web` forces the rebuild.

### Pre-existing CI failures, not caused by this PR

Expect the same red checks as on `master` and on the merged #45:

- **PHPStan**, **Storybook build**, **Install Varbase**, **Create reports** — all fail in the shared `Build the codebase` step, because setup-php's base PHP provides `pdo_pgsql` (8.4.24) regardless of the `extensions:` input, so `composer install` hits the same `replace` conflict on the runner. Red on `master` since #37. Tracked in #42.
- **platformsh** preview deployment — also failed identically on #45 and #47, so it is not related to this change.
- **PHPCS** and **YAML lint** pass.

## Checkpoints

- [x] File an issue
- [x] Addition/Change/Update/Fix
- [ ] Testing to ensure no regression
- [ ] Automated unit testing coverage
- [ ] Automated functional testing coverage
- [ ] Readability
- [ ] Accessibility
- [ ] Performance
- [ ] Security
- [ ] Developer Documentation
- [ ] User Guide Documentation
- [ ] Reviewed by a human
- [ ] Code review by maintainers
- [ ] Full testing and approval
- [ ] Credit contributors
- [ ] Release notes snippet
- [ ] Release
