### PR TITLE
Refresh the Composer lock file for Varbase Internationalization Base 1.0.0-rc3 #51

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2869,6 +2869,69 @@
             "time": "2026-03-18T20:09:59+00:00"
         },
         {
+            "name": "drupal/ai_tmgmt",
+            "version": "1.0.0-beta6",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/ai_tmgmt.git",
+                "reference": "1.0.0-beta6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/ai_tmgmt-1.0.0-beta6.zip",
+                "reference": "1.0.0-beta6",
+                "shasum": "1a520c3cfe599896a2692ad5b3e860fff2be4d03"
+            },
+            "require": {
+                "drupal/ai": "^1.0.4",
+                "drupal/core": "^10 || ^11",
+                "drupal/tmgmt": "^1.16"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0-beta6",
+                    "datestamp": "1781152697",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Minnur Yunusov (minnur)",
+                    "homepage": "https://www.drupal.org/u/minnur",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Scott Euser (scott_euser)",
+                    "homepage": "https://www.drupal.org/u/scott_euser",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "scott_euser",
+                    "homepage": "https://www.drupal.org/user/3267594"
+                }
+            ],
+            "description": "TMGMT implementation of AI Module to allow use of many AI Providers like OpenAI, Ollama, etc.",
+            "homepage": "http://drupal.org/project/ai_tmgmt",
+            "keywords": [
+                "AI",
+                "Drupal",
+                "TMGMT",
+                "Translation"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/ai_tmgmt",
+                "issues": "https://www.drupal.org/project/issues/ai_tmgmt"
+            }
+        },
+        {
             "name": "drupal/anchor_link",
             "version": "3.0.4",
             "source": {
@@ -15485,19 +15548,20 @@
         },
         {
             "name": "drupal/varbase_i18n_base",
-            "version": "1.0.0-rc2",
+            "version": "1.0.0-rc3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/varbase_i18n_base.git",
-                "reference": "f342a90d0e48d1eae41f21c119fc645cd167d30f"
+                "reference": "f89472d2954f54a5db6b50ee13a2d9f480a036be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://git.drupalcode.org/api/v4/projects/project%2Fvarbase_i18n_base/repository/archive.zip?sha=f342a90d0e48d1eae41f21c119fc645cd167d30f",
-                "reference": "f342a90d0e48d1eae41f21c119fc645cd167d30f",
+                "url": "https://git.drupalcode.org/api/v4/projects/project%2Fvarbase_i18n_base/repository/archive.zip?sha=f89472d2954f54a5db6b50ee13a2d9f480a036be",
+                "reference": "f89472d2954f54a5db6b50ee13a2d9f480a036be",
                 "shasum": ""
             },
             "require": {
+                "drupal/ai_tmgmt": "~1",
                 "drupal/core": "~11.4.0",
                 "drupal/eca": "~3",
                 "drupal/tmgmt": "~1"
@@ -15519,6 +15583,7 @@
                 "Drupal Canvas",
                 "TMGMT",
                 "Varbase recipes",
+                "ai translation",
                 "drupal recipe",
                 "drupal recipes",
                 "i18n",
@@ -15532,7 +15597,7 @@
                 "issues": "https://www.drupal.org/project/issues/varbase_i18n_base",
                 "source": "http://cgit.drupalcode.org/varbase_i18n_base"
             },
-            "time": "2026-08-20T14:31:34+00:00"
+            "time": "2026-08-23T17:08:57+00:00"
         },
         {
             "name": "drupal/varbase_media",


### PR DESCRIPTION
Issue: https://github.com/Vardot/platformsh-varbase/issues/51

Refreshes `composer.lock` on top of `1d6a2e7`. One file changed.

### Delta against master

| Package | Old | New |
| --- | --- | --- |
| Varbase Internationalization Base (`drupal/varbase_i18n_base`) | 1.0.0-rc2 | **1.0.0-rc3** |
| AI Translation Management Tool (`drupal/ai_tmgmt`) | — | **1.0.0-beta6** (new, required by the above) |

Package count 384 → 385. Nothing removed. Everything else holds still: Drupal core 11.4.5, Varbase 11.0.0-rc1, Varbase Patches 11.0.39, Drupal Core Patches 11.4.0.6, Drupal Canvas 1.10.1, Drupal AI 1.4.7.

No `composer.json` change — both packages resolve inside the existing constraints.

### patches.lock.json is intentionally not in this PR

The patch set is unchanged: **35 patched packages / 68 entries**, with an identical `_hash`, because neither upgraded package is patched. Committing it would be a no-op diff.

### Verification

Run in a DDEV clone of `master` (PHP 8.4, Drupal 11.4.5):

| Check | Result |
| --- | --- |
| `composer validate` | passes, only the pre-existing "version field is present" warning — **no stale-lock warning** |
| `composer patches-repatch` | all 68 entries re-applied, **0 failures**, with `composer-exit-on-patch-failure: true` |
| `composer install` from the lock | `Verifying lock file contents can be installed on current platform.` → `Nothing to install, update or remove` |
| `composer audit` | `No security vulnerability advisories found.` |

The non-zero exit on `composer audit` is the pre-existing abandoned `oomphinc/composer-installers-extender`, unchanged from master.

### Note on `drupal/ai_tmgmt`

It enters the lock as a **beta** (`1.0.0-beta6`), pulled in transitively by Varbase Internationalization Base 1.0.0-rc3 rather than requested directly. Flagging it because a beta arriving in a deployment template is worth a conscious nod; removing it would mean holding `varbase_i18n_base` at rc2.

## Checkpoints

- [x] File an issue
- [x] Addition/Change/Update/Fix
- [ ] Testing to ensure no regression
- [ ] Automated unit testing coverage
- [ ] Automated functional testing coverage
- [ ] Readability
- [ ] Accessibility
- [ ] Performance
- [ ] Security
- [ ] Developer Documentation
- [ ] User Guide Documentation
- [x] Reviewed by a human
- [x] Code review by maintainers
- [ ] Full testing and approval
- [ ] Credit contributors
- [ ] Release notes snippet
- [ ] Release
